### PR TITLE
some stuff I spotted in server as well

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,7 +1,7 @@
 var path = require('path')
 var express = require('express')
 var hbs = require ('express-handlebars')
-var routes = ('./routes/index')
+var routes = ('./routes')
 var bodyParser = require('body-parser')
 
 var PORT = 3000
@@ -13,7 +13,7 @@ app.set('views engine', 'hbs')
 app.set('views', path.join(__dirname + 'views'))
 // app.use(express.static('public'))
 
-app.get('/cate')
+app.get('/', routes.category)
 
 app.listen(PORT, function () {
   console.log('Listening on port', PORT)


### PR DESCRIPTION
Ok, line 16, your `app.get` needs the route you want to get to and a callback.
From what I understand, you wanted to render the `cate` table at your index route `'/'`? And I believe it was the `category` function in routes that was meant to do that?

I figured this format and syntax should do the job, but when I tested it, node complained as follows:
`Route.get() requires callbacks but got [Object Undefined]`
